### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-nsal

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,8 @@ NSAL_VERSION=${CORTXFS_VERSION:-"$(cat $NSAL_SOURCE_ROOT/VERSION)"}
 
 
 # Select NSAL Build Version.
-# Superproject: derived from cortxfs version.
-# Local: taken from git rev.
-NSAL_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of NSAL repo
+NSAL_BUILD_VERSION="$(git -C $NSAL_SOURCE_ROOT rev-parse --short HEAD)"
 
 # Optional, CORTX-UTILS source location.
 # Superproject: uses pre-defined location.


### PR DESCRIPTION
## Problem Statement:

https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-nsal

## Problem Description:

When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to git repo.

```
git -C <path_to_git_repo> rev-parse --short HEAD
```

## Tests
Before fix:
```
cortx-nsal-debuginfo-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-nsal-devel-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-nsal-1.0.0-7e45dd6.el7.x86_64.rpm
```
After fix:
```
cortx-nsal-debuginfo-1.0.0-7e717ad.el7.x86_64.rpm
cortx-nsal-devel-1.0.0-7e717ad.el7.x86_64.rpm
cortx-nsal-1.0.0-7e717ad.el7.x86_64.rpm
```
## Companion PRs
Seagate/cortx-utils#10
https://github.com/Seagate/cortx-dsal/pull/11
Seagate/cortx-fs#7
Seagate/cortx-fs-ganesha#11