### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-nsal using git-dir option

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,9 +31,9 @@ NSAL_VERSION=${CORTXFS_VERSION:-"$(cat $NSAL_SOURCE_ROOT/VERSION)"}
 
 
 # Select NSAL Build Version.
-# Superproject: derived from cortxfs version.
-# Local: taken from git rev.
-NSAL_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of NSAL repo
+GIT_DIR="$NSAL_SOURCE_ROOT/.git"
+NSAL_BUILD_VERSION="$(git --git-dir "$GIT_DIR" rev-parse --short HEAD)"
 
 # Optional, CORTX-UTILS source location.
 # Superproject: uses pre-defined location.


### PR DESCRIPTION
## Problem Statement:

https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-nsal

## Problem Description:

The previous solution only worked for git version higher than 1.8.5.
This solution works for git version 1.8.3. However, this solution is a bit tricky as we need to specify the `.git` explicitly.

When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.

```
git --git-dir <path_to_git_repo>/.git rev-parse --short HEAD
```

## Tests
Before fix:
```
cortx-nsal-debuginfo-1.0.0-1c32ae1.el7.x86_64.rpm
cortx-nsal-devel-1.0.0-1c32ae1.el7.x86_64.rpm
cortx-nsal-1.0.0-1c32ae1.el7.x86_64.rpm
```
After fix:
```
cortx-nsal-debuginfo-1.0.0-d715d73.el7.x86_64.rpm
cortx-nsal-devel-1.0.0-d715d73.el7.x86_64.rpm
cortx-nsal-1.0.0-d715d73.el7.x86_64.rpm
```
## Companion PRs
