### PR TITLE
EOS-8938:Added kvnode invariant

### DIFF
--- a/src/include/kvnode.h
+++ b/src/include/kvnode.h
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #ifndef _KVNODE_H_
@@ -254,4 +254,11 @@ int kvnode_del_sys_attr(const struct kvnode *node, const int key);
 uint16_t kvnode_get_basic_attr_buff(const struct kvnode *node,
 				    void **attr_buff);
 
+/* This API will validate the given kvnode is valid or not
+ *
+ * @param[in] node * - A pointer to kvnode which hold the opaque
+ *                     attribute information
+ * @return - true - if kvnode is valid, false - otherwise
+ */
+bool kvnode_invariant(const struct kvnode *node);
 #endif /* _KVNODE_H_ */

--- a/src/kvtree/kvnode.c
+++ b/src/kvtree/kvnode.c
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  * For any questions about this software or licensing,
- * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
  */
 
 #include "kvtree.h"
@@ -304,4 +304,13 @@ uint16_t kvnode_get_basic_attr_buff(const struct kvnode *node, void **attr_buff)
 	*attr_buff = (void *)basic_attr->attr;
 
 	return basic_attr->size;
+}
+
+bool kvnode_invariant(const struct kvnode *node)
+{
+	bool rc = (node != NULL) &&
+		  (node->basic_attr != NULL) &&
+		  (node->tree != NULL);
+
+	return rc;
 }


### PR DESCRIPTION
# NSAL Change Summary

## Problem Statement

_[EOS-8938](https://jts.seagate.com/browse/EOS-8938):_
_EOS-NFS: Implement File handle structure and ops_

## Problem Description

_As a part of new FH design, kvnode was added inside file handle and it's invariant was not available in kvnode code_

## Solution Overview

_Added kvnode_invariant inside kvnode.c file_

## Unit Test Cases
_All the UTs are passing_
_Able to create, export and mount the FS, able to do basic I/O_
_cthon test is passing General, Basic, Lock test cases_

## Companion MRs
- https://github.com/Seagate/cortx-fs-ganesha/pull/13
- https://github.com/Seagate/cortx-fs/pull/10

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [x] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned in description existing UTs are passing and related test cases are passing_
- [x] **Documentation:** _This patch, merge request, Jira ticket [EOS-8938](https://jts.seagate.com/browse/EOS-8938) have up to date description_