### PR TITLE
EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo nsal)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,14 @@ else (ENABLE_DASSERT)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 endif (ENABLE_DASSERT)
 
+# Turns on ADDB-based TDSB wrappers.
+# When this flag is disabled, perfc TSDB code will be turned off.
+# When this flag is enabled, the utils module has to be
+# compiled with this flag enabled otherwise some of
+# the function calls will be undefined.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
+
 message( STATUS "ENABLE_DASSERT : ${ENABLE_DASSERT}")
 
 include(CheckIncludeFiles)
@@ -254,6 +262,8 @@ configure_file(
 )
 
 set(RPMDEST "--define '_srcrpmdir ${CMAKE_CURRENT_BINARY_DIR}'")
+
+
 
 add_custom_target( rpms DEPENDS dist)
 add_custom_command(TARGET rpms


### PR DESCRIPTION
# EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo nsal)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
           commit c927fa48363a85c819913cafdfbca5088bd5b35d
           Author: pratyush-seagate <pratyush.k.khan@seagate.com>
           Date:   Mon Sep 28 22:49:32 2020 -0600

            EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo nsal)
            List of modified files:
                modified:   src/CMakeLists.txt
                modified:   src/kvstore/kvstore_base.c
            Change description:
                    Add new performance counters and integrate them further with other modules using newly added APIs
                    Addb APIs integration for read path
            Unit test:
                    Compilation with and without ENABLE_TSDB_ADDB flag
                    Addb unit test while integrated with read handler
                    Regular UTs (both with and without ENABLE_TSDB_ADDB flag)
            addb dump o/p from read handler after integration:
            * 2020-09-29-17:27:47.484505618            210ab ?               1?, ?               1?, ?            5035?, ?               1?
            * 2020-09-29-17:27:47.484506598            210cd ?               1?, ?               2?, ?            5035?, ?               5?, ?               0?
            * 2020-09-29-17:27:47.484507284            210cd ?               1?, ?               2?, ?            5035?, ?               6?, ?               1?
            * 2020-09-29-17:27:47.484508075            210cd ?               1?, ?               2?, ?            5035?, ?               7?, ?            1000?
            * 2020-09-29-17:27:47.484524037            210ab ?               4?, ?               1?, ?            5036?, ?               1?
            * 2020-09-29-17:27:47.484524850            210ef ?               4?, ?               3?, ?               6?, ?            5036?, ?            5035?
            * 2020-09-29-17:27:47.484525701            210cd ?               4?, ?               2?, ?            5036?, ?               a?, ?            1000?
            * 2020-09-29-17:27:47.484526538            210cd ?               4?, ?               2?, ?            5036?, ?               b?, ?               0?
            * 2020-09-29-17:27:47.484528239            210ab ?               2?, ?               1?, ?            5037?, ?               1?
            * 2020-09-29-17:27:47.484528994            210ef ?               2?, ?               3?, ?              10?, ?            5037?, ?            5035?
            * 2020-09-29-17:27:47.484529869            210cd ?               2?, ?               2?, ?            5037?, ?              10?, ?              12?
            * 2020-09-29-17:27:47.484531526            210cd ?               2?, ?               2?, ?            5037?, ?              11?, ?               0?
            * 2020-09-29-17:27:47.484532228            210ab ?               2?, ?               1?, ?            5037?, ?               2?
            * 2020-09-29-17:27:47.484533046            210ab ?               3?, ?               1?, ?            5038?, ?               1?
            * 2020-09-29-17:27:47.484533789            210ef ?               3?, ?               3?, ?              10?, ?            5038?, ?            5035?
            * 2020-09-29-17:27:47.484534649            210cd ?               3?, ?               2?, ?            5038?, ?              17?, ?              12?
            * 2020-09-29-17:27:47.484535507            210cd ?               3?, ?               2?, ?            5038?, ?              18?, ?               0?
            * 2020-09-29-17:27:47.487947750            210cd ?               3?, ?               2?, ?            5038?, ?              19?, ?               0?
            * 2020-09-29-17:27:47.487948775            210ab ?               3?, ?               1?, ?            5038?, ?               2?
