### PR TITLE
EOS-12583: Support global KVStore operations.

### DIFF
--- a/src/include/global_kvs.h
+++ b/src/include/global_kvs.h
@@ -1,0 +1,58 @@
+/*
+ * Filename: global_kvs.h
+ * Description: Declaration for NSAL global kvs api
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ */
+ 
+/** Global KV-Store operations **/
+/* The functionality provided by below APIs is dependent on basic
+ * framework provided kvstore.h
+ */ 
+
+#ifndef GLOBAL_KVS_H
+#define GLOBAL_KVS_H
+
+#include "kvstore.h"
+
+struct global_kvs_hdl {
+	kvs_idx_fid_t *fid;
+	struct kvstore *kvstore;
+	struct kvs_idx index;
+};
+
+/* Set an index mentioned by fid_str as global kvstore. Here it is assumed
+ * that the index has been created. Below call just opens the index. */
+int nsal_set_global_kvs(const char *fid_str);
+
+/* Allocate memory */
+int nsal_global_alloc(void **ptr, size_t size);
+
+/* Free the allocated memory */
+void nsal_global_free(void *ptr);
+
+/* Store KV pair in the global kvs */
+int nsal_global_set_kv(void *key, const size_t klen,
+		       void *value, const size_t vlen);
+
+/* Get KV pair stored in the global kvs */
+int nsal_global_get_kv(void *key, const size_t klen,
+		       void **value, size_t *vlen);
+
+/* Delete the KV pair stored in the global kvs */
+int nsal_global_del_kv(const void *key, size_t klen);
+
+
+#endif /*GLOBAL_KVS_H */

--- a/src/kvstore/CMakeLists.txt
+++ b/src/kvstore/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET(base_kvstore_LIB_SRCS
     kvstore_base.c
+    global_kvs.c
 )
 
 add_library(base_kvstore OBJECT ${base_kvstore_LIB_SRCS})

--- a/src/kvstore/global_kvs.c
+++ b/src/kvstore/global_kvs.c
@@ -1,0 +1,130 @@
+/*
+ * Filename : global_kvs.c
+ * Description : 
+ * 
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com.
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "kvstore.h"
+#include "global_kvs.h"
+
+/* Global definitions */
+struct global_kvs_hdl g_kvs_hdl;
+extern bool kvs_init_done;
+
+/* Set an index mentioned by fid_str as global kvstore. Here it is assumed that
+ * the index is created */
+int nsal_set_global_kvs(const char *fid_str)
+{
+	int rc = 0;
+
+	if (g_kvs_hdl.fid != NULL) {
+		log_err("Global KVS is already set \n");
+		rc = -EEXIST;
+		goto out;
+	}
+	if (!kvs_init_done) {
+		log_err("kvs_init is not done \n");
+		rc = -EINVAL;
+		goto out;
+	}
+	g_kvs_hdl.fid = malloc(sizeof(kvs_idx_fid_t));
+	if (g_kvs_hdl.fid == NULL) {
+		log_err("Unable to allocate memory \n");
+		goto out;
+	}
+	rc = kvs_fid_from_str(fid_str, g_kvs_hdl.fid);
+	if (rc) {
+		log_err("Failed to get fid \n");
+		free(g_kvs_hdl.fid);
+		goto out;
+	}
+	g_kvs_hdl.kvstore = kvstore_get();
+	rc = kvs_index_open(g_kvs_hdl.kvstore, g_kvs_hdl.fid, &g_kvs_hdl.index);
+	if (rc) {
+		log_err("Failed to open the index \n");
+		free(g_kvs_hdl.fid);
+		goto out;
+	}
+
+out:
+	return rc;
+}
+
+/* Memory allocation for key */
+int nsal_global_alloc(void **ptr, size_t size)
+{
+	return kvs_alloc(g_kvs_hdl.kvstore, ptr, size);
+}
+
+/* free up the allocated memory */
+void nsal_global_free(void *ptr)
+{
+	kvs_free(g_kvs_hdl.kvstore, ptr);
+}
+
+/* Store KV pair in the global kvs */
+int nsal_global_set_kv(void *key, const size_t klen,
+                       void *value, const size_t vlen)
+{
+	int rc = 0;
+
+	if (g_kvs_hdl.fid == NULL) {
+		log_err("Global KVS is not set \n");
+		rc = -EINVAL;
+		goto out;
+	}
+	rc = kvs_set(g_kvs_hdl.kvstore, &g_kvs_hdl.index, key, klen,
+		     value, vlen);
+
+out:
+	return rc;
+}
+
+/* Get KV pair stored in the global kvs */
+int nsal_global_get_kv(void *key, const size_t klen,
+                       void **value, size_t *vlen)
+{
+	int rc = 0;
+
+	if (g_kvs_hdl.fid == NULL) {
+		log_err("Global KVS is not set \n");
+		rc = -EINVAL;
+		goto out;
+	}
+	rc = kvs_get(g_kvs_hdl.kvstore, &g_kvs_hdl.index, key, klen,
+		     value, vlen);
+
+out:
+	return rc;
+}
+
+/* Delete the KV pair stored in the global kvs */
+int nsal_global_del_kv(const void *key, size_t klen)
+{
+	int rc = 0;
+
+	if (g_kvs_hdl.fid == NULL) {
+		log_err("Global KVS is not set \n");
+		rc = -EINVAL;
+		goto out;
+	}
+	rc = kvs_del(g_kvs_hdl.kvstore, &g_kvs_hdl.index, key, klen);
+
+out:
+	return rc;
+}

--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -33,6 +33,7 @@
 #define TYPE "type"
 
 static struct kvstore g_kvstore;
+bool kvs_init_done = false;
 
 struct kvstore_module {
     char *type;
@@ -89,6 +90,7 @@ static inline int __kvs_init(struct kvstore *kvstore,
 	}
 
 	kvstore->type = kvstore_type;
+	kvs_init_done = true;
 out:
 	return rc;
 }

--- a/src/test/ut/CMakeLists.txt
+++ b/src/test/ut/CMakeLists.txt
@@ -13,6 +13,7 @@ configure_file(ut_nsal.conf ut_nsal.conf COPYONLY)
 add_executable(ut_nsal_ns_ops ut_nsal_ns_ops.c)
 add_executable(ut_nsal_kvtree_ops ut_nsal_kvtree_ops.c)
 add_executable(ut_nsal_iter_ops ut_nsal_iter_ops.c)
+add_executable(ut_global_kvs ut_global_kvs.c)
 
 link_directories(${LIBKVSTORE})
 set(CMAKE_INSTALL_RPATH "${LIBKVSTORE}")
@@ -30,6 +31,12 @@ target_link_libraries(ut_nsal_iter_ops
 )
 
 target_link_libraries(ut_nsal_kvtree_ops
+	${PROJECT_NAME_BASE}-utils
+	${PROJECT_NAME_BASE}-nsal
+	${STORE_LIBRARY}
+)
+
+target_link_libraries(ut_global_kvs
 	${PROJECT_NAME_BASE}-utils
 	${PROJECT_NAME_BASE}-nsal
 	${STORE_LIBRARY}

--- a/src/test/ut/ut_global_kvs.c
+++ b/src/test/ut/ut_global_kvs.c
@@ -1,0 +1,201 @@
+/*
+ * Filename: ut_global_kvs.c
+ * Description: Implementation tests for global kvs support.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+#include <errno.h>
+#include <string.h>
+#include "debug.h"
+#include "common/log.h"
+#include "str.h"
+#include "global_kvs.h"
+#include "ut_nsal_ns.h"
+#include "nsal.h"
+
+#define DEFAULT_CONFIG "/etc/cortx/cortxfs.conf"
+
+struct test_key {
+	char type;
+	str256_t name;
+} test_key;
+
+/* Set the global kvs */
+static void test_nsal_set_global_kvs(void)
+{
+	struct collection_item *errors = NULL;
+	struct collection_item *cfg_items = NULL;
+	int rc = 0;
+
+	rc = log_init("/var/log/cortx/fs/cortxfs.log", LEVEL_DEBUG);
+	if (rc != 0) {
+		rc = -EINVAL;
+		printf("Log init failed, rc: %d\n", rc);
+		goto out;
+	}
+
+	rc = config_from_file("libcortxfs", DEFAULT_CONFIG, &cfg_items,
+			      INI_STOP_ON_ERROR, &errors);
+	if (rc) {
+		printf("Can't load config rc = %d", rc);
+		rc = -rc;
+		goto out;
+	}
+
+	rc = nsal_module_init(cfg_items);
+	if (rc) {
+		printf("nsal init failed rc = %d", rc);
+		rc = -rc;
+		goto out;
+	}
+
+	/* make use of kvs_fid as global kvs */
+	rc = nsal_set_global_kvs("<0x780000000000000b:1>");
+	if (rc) {
+		printf("nsal_set_global_kvs failed rc = %d", rc);
+		rc = -rc;
+		goto out;
+	}
+
+out:
+	if (rc) {
+		free_ini_config_errors(errors);
+	}
+
+	ut_assert_int_equal(rc, 0);
+}
+
+
+/**
+ * Test to add a KV pair in the global KVStore.
+ */
+static void test_nsal_global_set_kv(void)
+{
+	int rc = 0;
+	char *name = "component";
+	char *value = "cortxfs";
+	struct test_key *key1;
+
+	rc = nsal_global_alloc((void **)&key1, sizeof(struct test_key));
+	ut_assert_int_equal(rc, 0);
+
+	key1->type = 'T';
+	str256_from_cstr(key1->name, name, strlen(name));
+
+	rc = nsal_global_set_kv(key1, sizeof(struct test_key),
+				 (void*)value, strlen(value)+1);
+	ut_assert_int_equal(rc, 0);
+
+	nsal_global_free(key1);
+}
+
+/**
+ * Test to add a KV pair in the global KVStore.
+ */
+static void test_nsal_global_get_kv(void)
+{
+	int rc = 0;
+	char *name = "component";
+	char *value = "cortxfs";
+	char *val = NULL;
+	struct test_key *key1;
+	size_t vlen=0;
+
+	rc = nsal_global_alloc((void **)&key1, sizeof(struct test_key));
+	ut_assert_int_equal(rc, 0);
+
+	key1->type = 'T';
+	str256_from_cstr(key1->name, name, strlen(name));
+
+	rc = nsal_global_get_kv(key1, sizeof(struct test_key), (void**)&val,
+			    &vlen);
+	ut_assert_int_equal(rc, 0);
+
+	rc = strcmp(value, val);
+	ut_assert_int_equal(rc, 0);
+
+	nsal_global_free(key1);
+}
+
+/**
+ * Test to add a KV pair in the global KVStore.
+ */
+static void test_nsal_global_del_kv(void)
+{
+	int rc = 0;
+	char *name = "component";
+	char *val = NULL;
+	size_t vlen=0;
+	struct test_key *key1;
+
+	rc = nsal_global_alloc((void **)&key1, sizeof(struct test_key));
+	ut_assert_int_equal(rc, 0);
+
+	key1->type = 'T';
+	str256_from_cstr(key1->name, name, strlen(name));
+
+	rc = nsal_global_del_kv(key1, sizeof(struct test_key));
+	ut_assert_int_equal(rc, 0);
+
+	/* try to retrive the deleted key */
+	rc = nsal_global_get_kv(key1, sizeof(struct test_key), (void**)&val,
+			    &vlen);
+	ut_assert_int_equal(rc, -ENOENT);
+
+	nsal_global_free(key1);
+}
+
+
+int main(void)
+{
+	int rc = 0;
+	char *test_logs = "/var/log/cortx/test/ut/ut_nsal.logs";
+	int test_count, test_failed;
+
+	printf("Global KVS Tests\n");
+
+	rc = ut_load_config(CONF_FILE);
+	if (rc != 0) {
+		printf("ut_load_config: err = %d\n", rc);
+		goto end;
+	}
+
+	test_logs = ut_get_config("nsal", "log_path", test_logs);
+
+	rc = ut_init(test_logs);
+	if (rc != 0) {
+		printf("ut_init: err = %d\n", rc);
+		goto out;
+	}
+
+	struct test_case test_list[] = {
+		ut_test_case(test_nsal_set_global_kvs, NULL, NULL),
+		ut_test_case(test_nsal_global_set_kv, NULL, NULL),
+		ut_test_case(test_nsal_global_get_kv, NULL, NULL),
+		ut_test_case(test_nsal_global_del_kv, NULL, NULL),
+	};
+
+	test_count = sizeof(test_list) / sizeof(test_list[0]);
+	test_failed = ut_run(test_list, test_count, NULL, NULL);
+	ut_fini();
+	ut_summary(test_count, test_failed);
+
+out:
+	free(test_logs);
+
+end:
+	return rc;
+}


### PR DESCRIPTION
# CORTX-NSAL Change Summary

## Problem Statement

_[EOS-12583](https://jts.seagate.com/browse/EOS-12583):_
_Ability to set a global KVStore index and related operations_

## Problem Description

_CORTX-NSAL code do not support concept of global index and operations on the same. At times one need to work on a global index to store global information. Currently supported functionality do not provide such global framework, and
everytime one need to mention which index one want to work with in that KVStore._

## Solution Overview

_Functionality added such that one can specify an index which can be treated as global index, and support KV operations. Operations include set a KV pair, get the KV pair and delete the KV pair. Unit test is also provided._

### Companion PR
https://github.com/Seagate/cortx-posix/pull/286

## Unit Test Cases

NSAL UT is passing
$ sudo ./scripts/test.sh -t nsal
[sudo] password for 744293:
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned related test cases are passing_