### PR TITLE
EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations

### DIFF
--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -52,8 +52,8 @@ struct kvstore *kvstore_get(void)
 	return &g_kvstore;
 }
 
-int kvs_init(struct kvstore *kvstore, struct collection_item *cfg)
-
+static inline int __kvs_init(struct kvstore *kvstore,
+                            struct collection_item *cfg)
 {
 	int rc = 0, i;
 	char *kvstore_type = NULL;
@@ -93,11 +93,38 @@ out:
 	return rc;
 }
 
-int kvs_fini(struct kvstore *kvstore)
+int kvs_init(struct kvstore *kvstore, struct collection_item *cfg)
+{
+    int rc;
+
+    perfc_trace_inii(PFT_KVS_INIT, PEM_KVS_TO_NFS);
+
+    rc = __kvs_init(kvstore, cfg);
+
+    perfc_trace_attr(PEA_KVS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+    return rc;
+}
+static inline int __kvs_fini(struct kvstore *kvstore)
 {
 	dassert(kvstore && kvstore->kvstore_ops && kvstore->kvstore_ops->fini);
 
 	return kvstore->kvstore_ops->fini();
+}
+
+int kvs_fini(struct kvstore *kvstore)
+{
+    int rc;
+
+    perfc_trace_inii(PFT_KVS_FINI, PEM_KVS_TO_NFS);
+
+    rc = __kvs_fini(kvstore);
+
+    perfc_trace_attr(PEA_KVS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+    return rc;
 }
 
 int kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
@@ -105,7 +132,7 @@ int kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
 	return cortx_kvs_fid_from_str(fid_str, out_fid);
 }
 
-static int __kvs_alloc(struct kvstore *kvstore, void **ptr, size_t size)
+static inline int __kvs_alloc(struct kvstore *kvstore, void **ptr, size_t size)
 {
 	dassert(kvstore);
 	return kvstore->kvstore_ops->alloc(ptr, size);
@@ -120,16 +147,25 @@ int kvs_alloc(struct kvstore *kvstore, void **ptr, size_t size)
 
 	rc = __kvs_alloc(kvstore, ptr, size);
 
-	perfc_trace_attr(PEA_KVS_ALLOC_RES_RC, rc);
+	perfc_trace_attr(PEA_KVS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
 	return rc;
 }
 
-void kvs_free(struct kvstore *kvstore, void *ptr)
+static inline void __kvs_free(struct kvstore *kvstore, void *ptr)
 {
 	dassert(kvstore);
 	return kvstore->kvstore_ops->free(ptr);
+}
+
+void kvs_free(struct kvstore *kvstore, void *ptr)
+{
+    perfc_trace_inii(PFT_KVS_FREE, PEM_KVS_TO_NFS);
+
+    __kvs_free(kvstore, ptr);
+
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
 int kvs_begin_transaction(struct kvstore *kvstore, struct kvs_idx *index)
@@ -176,8 +212,8 @@ int kvs_index_close(struct kvstore *kvstore, struct kvs_idx *index)
 	return kvstore->kvstore_ops->index_close(index);
 }
 
-static int __kvs_get(struct kvstore *kvstore, struct kvs_idx *index, void *k,
-		     const size_t klen, void **v, size_t *vlen)
+static inline int __kvs_get(struct kvstore *kvstore, struct kvs_idx *index,
+                            void *k, const size_t klen, void **v, size_t *vlen)
 {
 	dassert(kvstore);
 	return kvstore->kvstore_ops->get_bin(index, k, klen, v, vlen);
@@ -189,24 +225,41 @@ int kvs_get(struct kvstore *kvstore, struct kvs_idx *index, void *k,
 	int rc;
 
 	perfc_trace_inii(PFT_KVS_GET, PEM_KVS_TO_NFS);
-	perfc_trace_attr(PEA_KVS_GET_KLEN, klen);
-	perfc_trace_attr(PEA_KVS_GET_VLEN, *vlen);
+	perfc_trace_attr(PEA_KVS_KLEN, klen);
+	perfc_trace_attr(PEA_KVS_VLEN, *vlen);
 
 	rc = __kvs_get(kvstore, index, k, klen, v, vlen);
 
-	perfc_trace_attr(PEA_KVS_GET_RES_RC, rc);
+	perfc_trace_attr(PEA_KVS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
 	return rc;
 }
 
-int kvs_set(struct kvstore *kvstore, struct kvs_idx *index, void *k, const size_t klen,
-	        void *v, const size_t vlen)
+static inline int __kvs_set(struct kvstore *kvstore, struct kvs_idx *index,
+                            void *k, const size_t klen,void *v,
+                            const size_t vlen)
 {
 	dassert(kvstore);
 	return kvstore->kvstore_ops->set_bin(index, k, klen, v, vlen);
 }
 
+int kvs_set(struct kvstore *kvstore, struct kvs_idx *index, void *k,
+            const size_t klen, void *v, const size_t vlen)
+{
+    int rc;
+
+    perfc_trace_inii(PFT_KVS_SET, PEM_KVS_TO_NFS);
+    perfc_trace_attr(PEA_KVS_KLEN, klen);
+    perfc_trace_attr(PEA_KVS_VLEN, vlen);
+
+    rc = __kvs_set(kvstore, index, k, klen, v, vlen);
+
+    perfc_trace_attr(PEA_KVS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+    return rc;
+}
 int kvs_del(struct kvstore *kvstore, struct kvs_idx *index, const void *k,
             size_t klen)
 {


### PR DESCRIPTION
Problem Statement
EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations
EOS-10522: NFS ADDB: Decoders for all file operations

Problem Description
Implement tracepoints and decoder for the attr handlers.

Solution Overview
Following changes has been done:

added wrapper over kvsfs_getattrs using kvsfs_perf_op_getattrs
Added traces for init and finish inside kvsfs_getattrs
Added traces for attributes like return code
added wrapper over kvsfs_setattrs using kvsfs_perf_op_setattrs
Added traces for init and finish inside kvsfs_setattrs
Added traces for attributes like return code
Added all enums in the decoder.
Unit Test Cases
`
sudo m0addb2dump -p /usr/lib64/libcortx-utils.so -- /addb_22028/o/100000000000000:2 | grep fsuser > addb_dump_op_decode_4

-bash-4.2$ cat addb_dump_op_decode_4 | grep "fsal_getattrs"

2020-10-08-01:13:36.571926218 fsuser_state fsal_getattrs, state, e, init
2020-10-08-01:13:36.576515604 fsuser_attribute fsal_getattrs, attribute, e, get_attribute_result_major_code, ? 0?
2020-10-08-01:13:36.576516264 fsuser_attribute fsal_getattrs, attribute, e, get_attribute_result_minor_code, ? 0?
2020-10-08-01:13:36.576516774 fsuser_state fsal_getattrs, state, e, finish
2020-10-08-01:14:01.444814040 fsuser_state fsal_getattrs, state, 36, init
2020-10-08-01:14:01.448805051 fsuser_attribute fsal_getattrs, attribute, 36, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:01.448805701 fsuser_attribute fsal_getattrs, attribute, 36, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:01.448806226 fsuser_state fsal_getattrs, state, 36, finish
2020-10-08-01:14:16.542089191 fsuser_state fsal_getattrs, state, c3, init
2020-10-08-01:14:16.546121912 fsuser_attribute fsal_getattrs, attribute, c3, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:16.546122558 fsuser_attribute fsal_getattrs, attribute, c3, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:16.546123094 fsuser_state fsal_getattrs, state, c3, finish
2020-10-08-01:14:29.730222059 fsuser_state fsal_getattrs, state, 17c, init
2020-10-08-01:14:29.734102240 fsuser_attribute fsal_getattrs, attribute, 17c, get_attribute_result_major_code, ? 0?
2020-10-08-01:14:29.734102870 fsuser_attribute fsal_getattrs, attribute, 17c, get_attribute_result_minor_code, ? 0?
2020-10-08-01:14:29.734103387 fsuser_state fsal_getattrs, state, 17c, finish
-bash-4.2$ cat addb_dump_op_decode_4 | grep "fsal_setattrs"

2020-10-08-01:14:34.079656624 fsuser_state fsal_setattrs, state, 566, init
2020-10-08-01:14:34.082418414 fsuser_attribute fsal_setattrs, attribute, 566, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:34.082419134 fsuser_attribute fsal_setattrs, attribute, 566, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:34.082419712 fsuser_state fsal_setattrs, state, 566, finish
2020-10-08-01:14:33.909490008 fsuser_state fsal_setattrs, state, 492, init
2020-10-08-01:14:33.912997100 fsuser_attribute fsal_setattrs, attribute, 492, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:33.912997868 fsuser_attribute fsal_setattrs, attribute, 492, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:33.912998408 fsuser_state fsal_setattrs, state, 492, finish
2020-10-08-01:14:55.922933569 fsuser_state fsal_setattrs, state, 7eb, init
2020-10-08-01:14:55.926658809 fsuser_attribute fsal_setattrs, attribute, 7eb, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:55.926660101 fsuser_attribute fsal_setattrs, attribute, 7eb, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:55.926660668 fsuser_state fsal_setattrs, state, 7eb, finish
2020-10-08-01:14:52.125471046 fsuser_state fsal_setattrs, state, 76e, init
2020-10-08-01:14:52.128594395 fsuser_attribute fsal_setattrs, attribute, 76e, set_attribute_result_major_code, ? 0?
2020-10-08-01:14:52.128595145 fsuser_attribute fsal_setattrs, attribute, 76e, set_attribute_result_minor_code, ? 0?
2020-10-08-01:14:52.128595686 fsuser_state fsal_setattrs, state, 76e, finish