### PR TITLE
EOS-13992: ADDB tracepoints for directory operations

### DIFF
--- a/src/kvtree/kvtree.c
+++ b/src/kvtree/kvtree.c
@@ -22,6 +22,7 @@
 #include "kvnode.h"
 #include "common/helpers.h" /* RC_WRAP_LABEL */
 #include "md_common.h"
+#include "operation.h"
 
 #define DEFAULT_ROOT_ID 2LL
 
@@ -277,7 +278,7 @@ out:
 }
 
 int kvtree_lookup(struct kvtree *tree, const node_id_t *parent_id,
-                  const str256_t *node_name, node_id_t *node_id)
+		  const str256_t *node_name, node_id_t *node_id)
 {
 	int rc = 0;
 	struct child_node_key *node_key = NULL;
@@ -348,8 +349,9 @@ int kvtree_has_children(struct kvtree *tree, const node_id_t *parent_id,
 	return rc;
 }
 
-int kvtree_iter_children(struct kvtree *tree, const node_id_t *parent_id,
-                         kvtree_iter_children_cb cb, void *cb_ctx)
+static inline int __kvtree_iter_children(struct kvtree *tree,
+		const node_id_t *parent_id, kvtree_iter_children_cb cb,
+		void *cb_ctx)
 {
 	struct child_node_key prefix = CHILD_NODE_PREFIX_INIT(parent_id);
 	int rc;
@@ -419,5 +421,17 @@ out:
 
 	log_debug("kvtree=%p, parent " NODE_ID_F ", rc=%d", tree,
 	           NODE_ID_P(parent_id), rc);
+	return rc;
+}
+
+int kvtree_iter_children(struct kvtree *tree, const node_id_t *parent_id,
+                         kvtree_iter_children_cb cb, void *cb_ctx)
+{
+	int rc;
+
+	perfc_trace_inii(PFT_KVTREE_ITER_CH, PEM_KVS_TO_NFS);
+	rc = __kvtree_iter_children(tree, parent_id, cb, cb_ctx);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
 	return rc;
 }


### PR DESCRIPTION
# CORTX-NSAL Change Summary

## Problem Statement
_[EOS-13992](https://jts.seagate.com/browse/EOS-13992):_
_ADDB Tracepoints-Directory Operations_

## Problem Description
_Add ADDB tracepoints for Directory operations_

## Solution Overview
_Directory operations include, directory creation (mkdir), directory removal (rmdir), read the directory contents (readdir) and lookup a specific entry in directory (lookup). ADDB tracepoint added for function entry and points. This provides information on how much time the function / code snippet takes._

### Companion PRs
https://github.com/Seagate/cortx-utils/pull/48
https://github.com/Seagate/cortx-fs-ganesha/pull/40
https://github.com/Seagate/cortx-fs/pull/41

## Unit Test Cases
_No new test cases added_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done as mentioned in testing above_
- [X] **Documentation:** _None_