### PR TITLE
EOS-14283: NFS ADDB: Trace points for all motr operations

### DIFF
--- a/src/common/motr/m0common.c
+++ b/src/common/motr/m0common.c
@@ -68,7 +68,7 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 {
 	struct m0_key_iter_priv *priv = m0_key_iter_priv(iter);
 
-    perfc_trace_inii(PFT_M0_KEY_ITER_FINISH, PEM_NFS_TO_MOTR);
+	perfc_trace_inii(PFT_M0_KEY_ITER_FINISH, PEM_NFS_TO_MOTR);
 	if (!priv->initialized)
 		goto out;
 
@@ -76,20 +76,20 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 	m0_bufvec_free(&priv->val);
 
 	if (priv->op) {
-        perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
-        perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
+		perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
+		perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
 
-        perfc_trace_attr(PEA_M0_OP_FINISH_START);
+		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FINISH);
 		m0_op_fini(priv->op);
-        perfc_trace_attr(PEA_M0_OP_FINISH_END);
+		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FINISH);
 
-        perfc_trace_attr(PEA_M0_OP_FREE_START);
+		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FREE);
 		m0_op_free(priv->op);
-        perfc_trace_attr(PEA_M0_OP_FREE_END);
+		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FREE);
 	}
 
 out:
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return;
 }
 
@@ -103,7 +103,7 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 	struct m0_idx *index = iter->idx.index_priv;
 	int rc;
 
-    perfc_trace_inii(PFT_M0_KEY_ITER_FIND, PEM_NFS_TO_MOTR);
+	perfc_trace_inii(PFT_M0_KEY_ITER_FIND, PEM_NFS_TO_MOTR);
 	if (prefix_len == 0)
 		rc = m0_bufvec_empty_alloc(key, 1);
 	else
@@ -119,26 +119,26 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 
 	memcpy(priv->key.ov_buf[0], prefix, prefix_len);
 
-    perfc_trace_attr(PEA_M0_IDX_OP_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_IDX_OP);
 	rc = m0_idx_op(index, M0_IC_NEXT, &priv->key, &priv->val,
 		       priv->rcs, 0, op);
-    perfc_trace_attr(PEA_M0_IDX_OP_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_IDX_OP);
 
 	if (rc != 0) {
 		goto out_free_val;
 	}
 
-    perfc_trace_attr(PEA_M0_OP_LAUNCH_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_LAUNCH);
 	m0_op_launch(op, 1);
-    perfc_trace_attr(PEA_M0_OP_LAUNCH_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_LAUNCH);
 
-    perfc_trace_attr(PEA_M0_OP_WAIT_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_WAIT);
 	rc = m0_op_wait(*op, M0_BITS(M0_OS_STABLE),
 			M0_TIME_NEVER);
-    perfc_trace_attr(PEA_M0_OP_WAIT_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_WAIT);
 
-    perfc_trace_attr(PEA_M0_OP_SM_ID, (*op)->op_sm.sm_id);
-    perfc_trace_attr(PEA_M0_OP_SM_STATE, (*op)->op_sm.sm_state);
+	perfc_trace_attr(PEA_M0_OP_SM_ID, (*op)->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_SM_STATE, (*op)->op_sm.sm_state);
 
 	if (rc != 0) {
 		goto out_free_op;
@@ -156,13 +156,13 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 
 out_free_op:
 	if (op && *op) {
-        perfc_trace_attr(PEA_M0_OP_FINISH_START);
+		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FINISH);
 		m0_op_fini(*op);
-        perfc_trace_attr(PEA_M0_OP_FINISH_END);
+		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FINISH);
 
-        perfc_trace_attr(PEA_M0_OP_FREE_START);
+		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FREE);
 		m0_op_free(*op);
-        perfc_trace_attr(PEA_M0_OP_FREE_END);
+		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FREE);
 	}
 
 out_free_val:
@@ -177,7 +177,7 @@ out:
 	}
 
 	iter->inner_rc = rc;
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc == 0;
 }
 
@@ -209,27 +209,27 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 	/* Motr API: "'vals' vector ... should contain NULLs" */
 	m0_bufvec_free_data(&priv->val);
 
-    perfc_trace_attr(PEA_M0_IDX_OP_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_IDX_OP);
 	iter->inner_rc = m0_idx_op(index, M0_IC_NEXT,
 				   &priv->key, &priv->val, priv->rcs,
 				   M0_OIF_EXCLUDE_START_KEY,  &priv->op);
-    perfc_trace_attr(PEA_M0_IDX_OP_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_IDX_OP);
 
 	if (iter->inner_rc != 0) {
 		goto out;
 	}
 
-    perfc_trace_attr(PEA_M0_OP_LAUNCH_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_LAUNCH);
 	m0_op_launch(&priv->op, 1);
-    perfc_trace_attr(PEA_M0_OP_LAUNCH_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_LAUNCH);
 
-    perfc_trace_attr(PEA_M0_OP_WAIT_START);
+	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_WAIT);
 	iter->inner_rc = m0_op_wait(priv->op, M0_BITS(M0_OS_STABLE),
 				    M0_TIME_NEVER);
-    perfc_trace_attr(PEA_M0_OP_WAIT_END);
+	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_WAIT);
 
-    perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
-    perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
+	perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
+	perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
 	if (iter->inner_rc != 0) {
 		goto out;
 	}
@@ -240,7 +240,7 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 		can_get_next = true;
 
 out:
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return can_get_next;
 }
 

--- a/src/common/motr/m0common.c
+++ b/src/common/motr/m0common.c
@@ -42,6 +42,7 @@
 #include "lib/thread.h"
 #include "m0common.h"
 #include <motr/helpers/helpers.h>
+#include "operation.h"
 
 /* Key Iterator */
 
@@ -67,6 +68,7 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 {
 	struct m0_key_iter_priv *priv = m0_key_iter_priv(iter);
 
+    perfc_trace_inii(PFT_M0_KEY_ITER_FINISH, PEM_NFS_TO_MOTR);
 	if (!priv->initialized)
 		goto out;
 
@@ -74,11 +76,20 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 	m0_bufvec_free(&priv->val);
 
 	if (priv->op) {
+        perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
+        perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
+
+        perfc_trace_attr(PEA_M0_OP_FINISH_START);
 		m0_op_fini(priv->op);
+        perfc_trace_attr(PEA_M0_OP_FINISH_END);
+
+        perfc_trace_attr(PEA_M0_OP_FREE_START);
 		m0_op_free(priv->op);
+        perfc_trace_attr(PEA_M0_OP_FREE_END);
 	}
 
 out:
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return;
 }
 
@@ -92,6 +103,7 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 	struct m0_idx *index = iter->idx.index_priv;
 	int rc;
 
+    perfc_trace_inii(PFT_M0_KEY_ITER_FIND, PEM_NFS_TO_MOTR);
 	if (prefix_len == 0)
 		rc = m0_bufvec_empty_alloc(key, 1);
 	else
@@ -107,17 +119,26 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 
 	memcpy(priv->key.ov_buf[0], prefix, prefix_len);
 
+    perfc_trace_attr(PEA_M0_IDX_OP_START);
 	rc = m0_idx_op(index, M0_IC_NEXT, &priv->key, &priv->val,
 		       priv->rcs, 0, op);
+    perfc_trace_attr(PEA_M0_IDX_OP_END);
 
 	if (rc != 0) {
 		goto out_free_val;
 	}
 
-
+    perfc_trace_attr(PEA_M0_OP_LAUNCH_START);
 	m0_op_launch(op, 1);
+    perfc_trace_attr(PEA_M0_OP_LAUNCH_END);
+
+    perfc_trace_attr(PEA_M0_OP_WAIT_START);
 	rc = m0_op_wait(*op, M0_BITS(M0_OS_STABLE),
 			M0_TIME_NEVER);
+    perfc_trace_attr(PEA_M0_OP_WAIT_END);
+
+    perfc_trace_attr(PEA_M0_OP_SM_ID, (*op)->op_sm.sm_id);
+    perfc_trace_attr(PEA_M0_OP_SM_STATE, (*op)->op_sm.sm_state);
 
 	if (rc != 0) {
 		goto out_free_op;
@@ -135,8 +156,13 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 
 out_free_op:
 	if (op && *op) {
+        perfc_trace_attr(PEA_M0_OP_FINISH_START);
 		m0_op_fini(*op);
+        perfc_trace_attr(PEA_M0_OP_FINISH_END);
+
+        perfc_trace_attr(PEA_M0_OP_FREE_START);
 		m0_op_free(*op);
+        perfc_trace_attr(PEA_M0_OP_FREE_END);
 	}
 
 out_free_val:
@@ -151,7 +177,7 @@ out:
 	}
 
 	iter->inner_rc = rc;
-
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc == 0;
 }
 
@@ -177,23 +203,33 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 	struct m0_idx *index = iter->idx.index_priv;
 	bool can_get_next = false;
 
+    perfc_trace_inii(PFT_M0_KEY_ITER_NEXT, PEM_NFS_TO_MOTR);
 	assert(priv->initialized);
 
 	/* Motr API: "'vals' vector ... should contain NULLs" */
 	m0_bufvec_free_data(&priv->val);
 
+    perfc_trace_attr(PEA_M0_IDX_OP_START);
 	iter->inner_rc = m0_idx_op(index, M0_IC_NEXT,
 				   &priv->key, &priv->val, priv->rcs,
 				   M0_OIF_EXCLUDE_START_KEY,  &priv->op);
+    perfc_trace_attr(PEA_M0_IDX_OP_END);
 
 	if (iter->inner_rc != 0) {
 		goto out;
 	}
 
+    perfc_trace_attr(PEA_M0_OP_LAUNCH_START);
 	m0_op_launch(&priv->op, 1);
+    perfc_trace_attr(PEA_M0_OP_LAUNCH_END);
+
+    perfc_trace_attr(PEA_M0_OP_WAIT_START);
 	iter->inner_rc = m0_op_wait(priv->op, M0_BITS(M0_OS_STABLE),
 				    M0_TIME_NEVER);
+    perfc_trace_attr(PEA_M0_OP_WAIT_END);
 
+    perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
+    perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
 	if (iter->inner_rc != 0) {
 		goto out;
 	}
@@ -204,6 +240,7 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 		can_get_next = true;
 
 out:
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return can_get_next;
 }
 

--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -53,7 +53,7 @@ struct kvstore *kvstore_get(void)
 }
 
 static inline int __kvs_init(struct kvstore *kvstore,
-                            struct collection_item *cfg)
+                             struct collection_item *cfg)
 {
 	int rc = 0, i;
 	char *kvstore_type = NULL;
@@ -95,16 +95,16 @@ out:
 
 int kvs_init(struct kvstore *kvstore, struct collection_item *cfg)
 {
-    int rc;
+	int rc;
 
-    perfc_trace_inii(PFT_KVS_INIT, PEM_KVS_TO_NFS);
+	perfc_trace_inii(PFT_KVS_INIT, PEM_KVS_TO_NFS);
 
-    rc = __kvs_init(kvstore, cfg);
+	rc = __kvs_init(kvstore, cfg);
 
-    perfc_trace_attr(PEA_KVS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_attr(PEA_KVS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
-    return rc;
+	return rc;
 }
 static inline int __kvs_fini(struct kvstore *kvstore)
 {
@@ -115,16 +115,16 @@ static inline int __kvs_fini(struct kvstore *kvstore)
 
 int kvs_fini(struct kvstore *kvstore)
 {
-    int rc;
+	int rc;
 
-    perfc_trace_inii(PFT_KVS_FINI, PEM_KVS_TO_NFS);
+	perfc_trace_inii(PFT_KVS_FINI, PEM_KVS_TO_NFS);
 
-    rc = __kvs_fini(kvstore);
+	rc = __kvs_fini(kvstore);
 
-    perfc_trace_attr(PEA_KVS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_attr(PEA_KVS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
-    return rc;
+	return rc;
 }
 
 int kvs_fid_from_str(const char *fid_str, kvs_idx_fid_t *out_fid)
@@ -161,11 +161,11 @@ static inline void __kvs_free(struct kvstore *kvstore, void *ptr)
 
 void kvs_free(struct kvstore *kvstore, void *ptr)
 {
-    perfc_trace_inii(PFT_KVS_FREE, PEM_KVS_TO_NFS);
+	perfc_trace_inii(PFT_KVS_FREE, PEM_KVS_TO_NFS);
 
-    __kvs_free(kvstore, ptr);
+	__kvs_free(kvstore, ptr);
 
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
 int kvs_begin_transaction(struct kvstore *kvstore, struct kvs_idx *index)
@@ -220,7 +220,7 @@ static inline int __kvs_get(struct kvstore *kvstore, struct kvs_idx *index,
 }
 
 int kvs_get(struct kvstore *kvstore, struct kvs_idx *index, void *k,
-	    const size_t klen, void **v, size_t *vlen)
+	G1G    const size_t klen, void **v, size_t *vlen)
 {
 	int rc;
 
@@ -245,20 +245,20 @@ static inline int __kvs_set(struct kvstore *kvstore, struct kvs_idx *index,
 }
 
 int kvs_set(struct kvstore *kvstore, struct kvs_idx *index, void *k,
-            const size_t klen, void *v, const size_t vlen)
+			const size_t klen, void *v, const size_t vlen)
 {
-    int rc;
+	int rc;
 
-    perfc_trace_inii(PFT_KVS_SET, PEM_KVS_TO_NFS);
-    perfc_trace_attr(PEA_KVS_KLEN, klen);
-    perfc_trace_attr(PEA_KVS_VLEN, vlen);
+	perfc_trace_inii(PFT_KVS_SET, PEM_KVS_TO_NFS);
+	perfc_trace_attr(PEA_KVS_KLEN, klen);
+	perfc_trace_attr(PEA_KVS_VLEN, vlen);
 
-    rc = __kvs_set(kvstore, index, k, klen, v, vlen);
+	rc = __kvs_set(kvstore, index, k, klen, v, vlen);
 
-    perfc_trace_attr(PEA_KVS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	perfc_trace_attr(PEA_KVS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
-    return rc;
+	return rc;
 }
 int kvs_del(struct kvstore *kvstore, struct kvs_idx *index, const void *k,
             size_t klen)

--- a/src/kvstore/plugins/cortx/cortx_kvstore.c
+++ b/src/kvstore/plugins/cortx/cortx_kvstore.c
@@ -24,45 +24,61 @@
  
 #include "internal/cortx/cortx_kvstore.h"
 #include <cortx/helpers.h>
+#include "operation.h"
 
 int cortx_kvs_init(struct collection_item *cfg_items)
 {
-	return m0init(cfg_items);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS_INIT, PEM_NSAL_TO_MOTR);
+	rc = m0init(cfg_items);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs_fini(void)
 {
+    perfc_trace_inii(PFT_CORTX_KVS_FINISH, PEM_NSAL_TO_MOTR);
 	m0fini();
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return 0;
 }
 
 int cortx_kvs_alloc(void **ptr, size_t size)
 {
+    perfc_trace_inii(PFT_CORTX_KVS_ALLOC, PEM_NSAL_TO_MOTR);
 	*ptr = m0kvs_alloc(size);
-	if (*ptr == NULL)
+	if (*ptr == NULL) {
+        perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 		return -ENOMEM;
+    }
 
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return 0;
 }
 
 void cortx_kvs_free(void *ptr)
 {
-	return m0kvs_free(ptr);
+    perfc_trace_inii(PFT_CORTX_KVS_FREE, PEM_NSAL_TO_MOTR);
+	m0kvs_free(ptr);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return;
 }
 
 
 int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
-        int rc;
+    int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
 	index->index_priv = NULL;
 
+    perfc_trace_inii(PFT_CORTX_KVS_INDEX_CREATE, PEM_NSAL_TO_MOTR);
+
 	if (fid == NULL) {
-		const char *vfid_str = cortx_kvs_get_gfid();
-	        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
+        const char *vfid_str = cortx_kvs_get_gfid();
+        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
 
 		index->index_fid = gfid;
 
@@ -77,35 +93,40 @@ int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	}
 
-
-        rc = m0idx_create(&mfid, &idx);
-        if (rc != 0) {
-                fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
-			mfid.u_hi, mfid.u_lo);
+    rc = m0idx_create(&mfid, &idx);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
+                mfid.u_hi, mfid.u_lo);
 		goto out;
 	}
 
 	/** Use KVStore index's priv to track Motr motr index */
 	index->index_priv = idx;
 out:
-        return rc;
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+    return rc;
 }
 
 int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
 {
-        int rc;
+    int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 
+    perfc_trace_inii(PFT_CORTX_KVS_INDEX_DELETE, PEM_NSAL_TO_MOTR);
 	mfid.u_hi = fid->f_hi;
 	mfid.u_lo = fid->f_lo;
 
-        rc = m0idx_delete(&mfid);
-        if (rc != 0) {
-                fprintf(stderr, "Failed to delete index, fid=%" PRIx64 ":%" PRIx64 "\n",
-			mfid.u_hi, mfid.u_lo);
+    rc = m0idx_delete(&mfid);
+    if (rc != 0) {
+        fprintf(stderr, "Failed to delete index, fid=%" PRIx64 ":%" PRIx64 "\n",
+                mfid.u_hi, mfid.u_lo);
 	}
 
-        return rc;
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
@@ -115,12 +136,14 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
+    perfc_trace_inii(PFT_CORTX_KVS_INDEX_OPEN, PEM_NSAL_TO_MOTR);
+
 	index->index_priv = NULL;
 
 	if (fid == NULL) {
 		const char *vfid_str = cortx_kvs_get_gfid();
 
-	        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
+        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
 
 		index->index_fid = gfid;
 
@@ -143,6 +166,8 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	index->index_priv = idx;
 out:
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
 }
 
@@ -150,12 +175,15 @@ int cortx_kvs_index_close(struct kvs_idx *index)
 {
 	struct m0_idx *idx = (struct m0_idx *)index->index_priv;
 
-        m0idx_close(idx);
+    perfc_trace_inii(PFT_CORTX_KVS_INDEX_CLOSE, PEM_NSAL_TO_MOTR);
+
+    m0idx_close(idx);
 
 	index->index_priv = NULL;
 	index->index_fid.f_hi = 0;
 	index->index_fid.f_lo = 0;
 
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return 0;
 }
 
@@ -177,33 +205,63 @@ int cortx_kvs_discard_transaction(struct kvs_idx *index)
 int cortx_kvs_get_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void **v, size_t *vlen)
 {
-	return m0kvs_get(index->index_priv, k, klen, v, vlen);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS_GET_BIN, PEM_NSAL_TO_MOTR);
+    rc = m0kvs_get(index->index_priv, k, klen, v, vlen);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs4_get_bin(void *k, const size_t klen, void **v, size_t *vlen)
 {
-	return m0kvs4_get(k, klen, v, vlen);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS4_GET_BIN, PEM_NSAL_TO_MOTR);
+    rc = m0kvs4_get(k, klen, v, vlen);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs_set_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void *v, const size_t vlen)
 {
-	return m0kvs_set(index->index_priv, k, klen, v, vlen);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS_SET_BIN, PEM_NSAL_TO_MOTR);
+    rc = m0kvs_set(index->index_priv, k, klen, v, vlen);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs4_set_bin(void *k, const size_t klen, void *v, const size_t vlen)
 {
-	return m0kvs4_set(k, klen, v, vlen);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS4_SET_BIN, PEM_NSAL_TO_MOTR);
+    rc = m0kvs4_set(k, klen, v, vlen);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs_del_bin(struct kvs_idx *index, const void *key, size_t klen)
 {
-	return m0kvs_del(index->index_priv, (void *) key, klen);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS_DELETE_BIN, PEM_NSAL_TO_MOTR);
+    rc = m0kvs_del(index->index_priv, (void *) key, klen);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 int cortx_kvs_gen_fid(kvs_idx_fid_t *index_fid)
 {
-	return m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
+    int rc;
+    perfc_trace_inii(PFT_CORTX_KVS_GEN_FID, PEM_NSAL_TO_MOTR);
+    rc = m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+    return rc;
 }
 
 const char *cortx_kvs_get_gfid(void)
@@ -233,11 +291,15 @@ int cortx_kvs_get_list_size(void *ctx, char *pattern, size_t plen)
 	int size = 0;
 	int rc;
 
+    perfc_trace_inii(PFT_CORTX_KVS_GET_LIST_SIZE, PEM_NSAL_TO_MOTR);
 	strcpy(initk, pattern);
 	initk[plen - 2] = '\0';
 
 	rc = m0kvs_pattern(ctx, initk, pattern,
 			   get_list_cb_size, &size);
+    perfc_trace_attr(PEA_KVS_LIST_SIZE, size);
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	if (rc < 0)
 		return rc;
 
@@ -261,7 +323,9 @@ void cortx_kvs_iter_get_kv(struct kvs_itr *iter, void **key, size_t *klen,
                            void **val, size_t *vlen)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
-	return m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
+    perfc_trace_inii(PFT_CORTX_KVS_ITER_GET_KV, PEM_NSAL_TO_MOTR);
+	m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
 int cortx_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
@@ -291,6 +355,8 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	int rc = 0;
 	struct m0kvs_key_iter *priv = NULL;
 
+    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FIND, PEM_NSAL_TO_MOTR);
+
 	priv = cortx_key_iter_priv(iter);
 	priv->index = iter->idx.index_priv;
 	rc = m0kvs_key_iter_find(iter->prefix.buf, iter->prefix.len, priv);
@@ -300,6 +366,8 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
 }
 
@@ -307,6 +375,7 @@ out:
 int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 {
 	int rc = 0;
+    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_NEXT, PEM_NSAL_TO_MOTR);
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	rc = m0kvs_key_iter_next(priv);
 	iter->inner_rc = rc;
@@ -315,6 +384,8 @@ int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
+    perfc_trace_attr(PEA_NS_RES_RC, rc);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
 }
 
@@ -322,7 +393,9 @@ out:
 void cortx_kvs_prefix_iter_fini(struct kvs_itr *iter)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
+    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FINISH, PEM_NSAL_TO_MOTR);
 	m0kvs_key_iter_fini(priv);
+    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 }
 
 struct kvstore_ops cortx_kvs_ops = {

--- a/src/kvstore/plugins/cortx/cortx_kvstore.c
+++ b/src/kvstore/plugins/cortx/cortx_kvstore.c
@@ -28,23 +28,38 @@
 
 int cortx_kvs_init(struct collection_item *cfg_items)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS_INIT, PEM_NSAL_TO_MOTR);
 	rc = m0init(cfg_items);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS_INIT, PEM_NSAL_TO_MOTR);
+	rc = m0init(cfg_items);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_fini(void)
 {
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_FINISH, PEM_NSAL_TO_MOTR);
 	m0fini();
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_FINISH, PEM_NSAL_TO_MOTR);
+	m0fini();
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
 int cortx_kvs_alloc(void **ptr, size_t size)
 {
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_ALLOC, PEM_NSAL_TO_MOTR);
 	*ptr = m0kvs_alloc(size);
 	if (*ptr == NULL) {
@@ -53,28 +68,53 @@ int cortx_kvs_alloc(void **ptr, size_t size)
     }
 
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_ALLOC, PEM_NSAL_TO_MOTR);
+	*ptr = m0kvs_alloc(size);
+	if (*ptr == NULL) {
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+		return -ENOMEM;
+	}
+
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
 void cortx_kvs_free(void *ptr)
 {
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_FREE, PEM_NSAL_TO_MOTR);
 	m0kvs_free(ptr);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return;
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_FREE, PEM_NSAL_TO_MOTR);
+	m0kvs_free(ptr);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 
 int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
+<<<<<<< HEAD
     int rc;
+=======
+	int rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
 	index->index_priv = NULL;
 
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_INDEX_CREATE, PEM_NSAL_TO_MOTR);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_INDEX_CREATE, PEM_NSAL_TO_MOTR);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	if (fid == NULL) {
         const char *vfid_str = cortx_kvs_get_gfid();
@@ -93,24 +133,39 @@ int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	}
 
+<<<<<<< HEAD
     rc = m0idx_create(&mfid, &idx);
     if (rc != 0) {
         fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
                 mfid.u_hi, mfid.u_lo);
+=======
+	rc = m0idx_create(&mfid, &idx);
+	if (rc != 0) {
+		fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
+				mfid.u_hi, mfid.u_lo);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 		goto out;
 	}
 
 	/** Use KVStore index's priv to track Motr motr index */
 	index->index_priv = idx;
 out:
+<<<<<<< HEAD
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
     return rc;
+=======
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
 {
+<<<<<<< HEAD
     int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 
@@ -127,6 +182,24 @@ int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	struct m0_uint128 mfid = M0_UINT128(0, 0);
+
+	perfc_trace_inii(PFT_CORTX_KVS_INDEX_DELETE, PEM_NSAL_TO_MOTR);
+	mfid.u_hi = fid->f_hi;
+	mfid.u_lo = fid->f_lo;
+
+	rc = m0idx_delete(&mfid);
+    if (rc != 0) {
+		fprintf(stderr, "Failed to delete index, fid=%" PRIx64 ":%" PRIx64 "\n",
+				mfid.u_hi, mfid.u_lo);
+	}
+
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
@@ -136,14 +209,22 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_INDEX_OPEN, PEM_NSAL_TO_MOTR);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_INDEX_OPEN, PEM_NSAL_TO_MOTR);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	index->index_priv = NULL;
 
 	if (fid == NULL) {
 		const char *vfid_str = cortx_kvs_get_gfid();
 
+<<<<<<< HEAD
         rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
+=======
+		rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 		index->index_fid = gfid;
 
@@ -166,8 +247,13 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	index->index_priv = idx;
 out:
+<<<<<<< HEAD
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -175,15 +261,25 @@ int cortx_kvs_index_close(struct kvs_idx *index)
 {
 	struct m0_idx *idx = (struct m0_idx *)index->index_priv;
 
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_INDEX_CLOSE, PEM_NSAL_TO_MOTR);
 
     m0idx_close(idx);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_INDEX_CLOSE, PEM_NSAL_TO_MOTR);
+
+	m0idx_close(idx);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	index->index_priv = NULL;
 	index->index_fid.f_hi = 0;
 	index->index_fid.f_lo = 0;
 
+<<<<<<< HEAD
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
@@ -205,63 +301,117 @@ int cortx_kvs_discard_transaction(struct kvs_idx *index)
 int cortx_kvs_get_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void **v, size_t *vlen)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS_GET_BIN, PEM_NSAL_TO_MOTR);
     rc = m0kvs_get(index->index_priv, k, klen, v, vlen);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS_GET_BIN, PEM_NSAL_TO_MOTR);
+	rc = m0kvs_get(index->index_priv, k, klen, v, vlen);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs4_get_bin(void *k, const size_t klen, void **v, size_t *vlen)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS4_GET_BIN, PEM_NSAL_TO_MOTR);
     rc = m0kvs4_get(k, klen, v, vlen);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS4_GET_BIN, PEM_NSAL_TO_MOTR);
+	rc = m0kvs4_get(k, klen, v, vlen);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_set_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void *v, const size_t vlen)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS_SET_BIN, PEM_NSAL_TO_MOTR);
     rc = m0kvs_set(index->index_priv, k, klen, v, vlen);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS_SET_BIN, PEM_NSAL_TO_MOTR);
+	rc = m0kvs_set(index->index_priv, k, klen, v, vlen);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs4_set_bin(void *k, const size_t klen, void *v, const size_t vlen)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS4_SET_BIN, PEM_NSAL_TO_MOTR);
     rc = m0kvs4_set(k, klen, v, vlen);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS4_SET_BIN, PEM_NSAL_TO_MOTR);
+	rc = m0kvs4_set(k, klen, v, vlen);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_del_bin(struct kvs_idx *index, const void *key, size_t klen)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS_DELETE_BIN, PEM_NSAL_TO_MOTR);
     rc = m0kvs_del(index->index_priv, (void *) key, klen);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS_DELETE_BIN, PEM_NSAL_TO_MOTR);
+	rc = m0kvs_del(index->index_priv, (void *) key, klen);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_gen_fid(kvs_idx_fid_t *index_fid)
 {
+<<<<<<< HEAD
     int rc;
     perfc_trace_inii(PFT_CORTX_KVS_GEN_FID, PEM_NSAL_TO_MOTR);
     rc = m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
     return rc;
+=======
+	int rc;
+	perfc_trace_inii(PFT_CORTX_KVS_GEN_FID, PEM_NSAL_TO_MOTR);
+	rc = m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+	return rc;
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 const char *cortx_kvs_get_gfid(void)
@@ -291,15 +441,25 @@ int cortx_kvs_get_list_size(void *ctx, char *pattern, size_t plen)
 	int size = 0;
 	int rc;
 
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_GET_LIST_SIZE, PEM_NSAL_TO_MOTR);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_GET_LIST_SIZE, PEM_NSAL_TO_MOTR);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	strcpy(initk, pattern);
 	initk[plen - 2] = '\0';
 
 	rc = m0kvs_pattern(ctx, initk, pattern,
 			   get_list_cb_size, &size);
+<<<<<<< HEAD
     perfc_trace_attr(PEA_KVS_LIST_SIZE, size);
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_attr(PEA_KVS_LIST_SIZE, size);
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	if (rc < 0)
 		return rc;
 
@@ -323,9 +483,15 @@ void cortx_kvs_iter_get_kv(struct kvs_itr *iter, void **key, size_t *klen,
                            void **val, size_t *vlen)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_ITER_GET_KV, PEM_NSAL_TO_MOTR);
 	m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_ITER_GET_KV, PEM_NSAL_TO_MOTR);
+	m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
@@ -355,7 +521,11 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	int rc = 0;
 	struct m0kvs_key_iter *priv = NULL;
 
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FIND, PEM_NSAL_TO_MOTR);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FIND, PEM_NSAL_TO_MOTR);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	priv = cortx_key_iter_priv(iter);
 	priv->index = iter->idx.index_priv;
@@ -366,8 +536,13 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
+<<<<<<< HEAD
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -375,7 +550,11 @@ out:
 int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 {
 	int rc = 0;
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_NEXT, PEM_NSAL_TO_MOTR);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_NEXT, PEM_NSAL_TO_MOTR);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	rc = m0kvs_key_iter_next(priv);
 	iter->inner_rc = rc;
@@ -384,8 +563,13 @@ int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
+<<<<<<< HEAD
     perfc_trace_attr(PEA_NS_RES_RC, rc);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_attr(PEA_NS_RES_RC, rc);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -393,9 +577,15 @@ out:
 void cortx_kvs_prefix_iter_fini(struct kvs_itr *iter)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
+<<<<<<< HEAD
     perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FINISH, PEM_NSAL_TO_MOTR);
 	m0kvs_key_iter_fini(priv);
     perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+=======
+	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FINISH, PEM_NSAL_TO_MOTR);
+	m0kvs_key_iter_fini(priv);
+	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
+>>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 struct kvstore_ops cortx_kvs_ops = {


### PR DESCRIPTION
**Problem Statement**
EOS-14283: NFS ADDB: Trace points for all motr operations

**Problem Description**
There was no way NFS ADDB can trace the time required for motr apis. We need to come up with connection point where we can trace the motr api.  

**Solution Overview**
Added performance counter START and END before and after Motr api. 
Also, Added traces for sm_id and sm_state after motr api completed to trace the motr api in there addb call graph.
 
**Unit Test Cases**
![image](https://user-images.githubusercontent.com/68695688/96445324-598a5b80-122d-11eb-98d1-d951551a2554.png)
