### PR TITLE
EOS-14283: resolved conflicts and build failure

### DIFF
--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -220,7 +220,7 @@ static inline int __kvs_get(struct kvstore *kvstore, struct kvs_idx *index,
 }
 
 int kvs_get(struct kvstore *kvstore, struct kvs_idx *index, void *k,
-	G1G    const size_t klen, void **v, size_t *vlen)
+	    const size_t klen, void **v, size_t *vlen)
 {
 	int rc;
 

--- a/src/kvstore/plugins/cortx/cortx_kvstore.c
+++ b/src/kvstore/plugins/cortx/cortx_kvstore.c
@@ -28,47 +28,23 @@
 
 int cortx_kvs_init(struct collection_item *cfg_items)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS_INIT, PEM_NSAL_TO_MOTR);
-	rc = m0init(cfg_items);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS_INIT, PEM_NSAL_TO_MOTR);
 	rc = m0init(cfg_items);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_fini(void)
 {
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_FINISH, PEM_NSAL_TO_MOTR);
-	m0fini();
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_FINISH, PEM_NSAL_TO_MOTR);
 	m0fini();
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
 int cortx_kvs_alloc(void **ptr, size_t size)
 {
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_ALLOC, PEM_NSAL_TO_MOTR);
-	*ptr = m0kvs_alloc(size);
-	if (*ptr == NULL) {
-        perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-		return -ENOMEM;
-    }
-
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_ALLOC, PEM_NSAL_TO_MOTR);
 	*ptr = m0kvs_alloc(size);
 	if (*ptr == NULL) {
@@ -77,44 +53,28 @@ int cortx_kvs_alloc(void **ptr, size_t size)
 	}
 
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
 void cortx_kvs_free(void *ptr)
 {
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_FREE, PEM_NSAL_TO_MOTR);
-	m0kvs_free(ptr);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return;
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_FREE, PEM_NSAL_TO_MOTR);
 	m0kvs_free(ptr);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 
 int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 {
-<<<<<<< HEAD
-    int rc;
-=======
 	int rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
 	index->index_priv = NULL;
 
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_INDEX_CREATE, PEM_NSAL_TO_MOTR);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_INDEX_CREATE, PEM_NSAL_TO_MOTR);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	if (fid == NULL) {
         const char *vfid_str = cortx_kvs_get_gfid();
@@ -133,56 +93,24 @@ int cortx_kvs_index_create(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	}
 
-<<<<<<< HEAD
-    rc = m0idx_create(&mfid, &idx);
-    if (rc != 0) {
-        fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
-                mfid.u_hi, mfid.u_lo);
-=======
 	rc = m0idx_create(&mfid, &idx);
 	if (rc != 0) {
 		fprintf(stderr, "Failed to create index, fid=%" PRIx64 ":%" PRIx64 "\n",
 				mfid.u_hi, mfid.u_lo);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 		goto out;
 	}
 
 	/** Use KVStore index's priv to track Motr motr index */
 	index->index_priv = idx;
 out:
-<<<<<<< HEAD
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-
-    return rc;
-=======
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
 {
-<<<<<<< HEAD
-    int rc;
-	struct m0_uint128 mfid = M0_UINT128(0, 0);
-
-    perfc_trace_inii(PFT_CORTX_KVS_INDEX_DELETE, PEM_NSAL_TO_MOTR);
-	mfid.u_hi = fid->f_hi;
-	mfid.u_lo = fid->f_lo;
-
-    rc = m0idx_delete(&mfid);
-    if (rc != 0) {
-        fprintf(stderr, "Failed to delete index, fid=%" PRIx64 ":%" PRIx64 "\n",
-                mfid.u_hi, mfid.u_lo);
-	}
-
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	struct m0_uint128 mfid = M0_UINT128(0, 0);
 
@@ -199,7 +127,6 @@ int cortx_kvs_index_delete(const kvs_idx_fid_t *fid)
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
@@ -209,22 +136,14 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 	struct m0_idx *idx = NULL;
 	kvs_idx_fid_t gfid;
 
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_INDEX_OPEN, PEM_NSAL_TO_MOTR);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_INDEX_OPEN, PEM_NSAL_TO_MOTR);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	index->index_priv = NULL;
 
 	if (fid == NULL) {
 		const char *vfid_str = cortx_kvs_get_gfid();
 
-<<<<<<< HEAD
-        rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
-=======
 		rc = cortx_kvs_fid_from_str(vfid_str, &gfid);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 		index->index_fid = gfid;
 
@@ -247,13 +166,8 @@ int cortx_kvs_index_open(const kvs_idx_fid_t *fid, struct kvs_idx *index)
 
 	index->index_priv = idx;
 out:
-<<<<<<< HEAD
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -261,25 +175,15 @@ int cortx_kvs_index_close(struct kvs_idx *index)
 {
 	struct m0_idx *idx = (struct m0_idx *)index->index_priv;
 
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_INDEX_CLOSE, PEM_NSAL_TO_MOTR);
-
-    m0idx_close(idx);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_INDEX_CLOSE, PEM_NSAL_TO_MOTR);
 
 	m0idx_close(idx);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	index->index_priv = NULL;
 	index->index_fid.f_hi = 0;
 	index->index_fid.f_lo = 0;
 
-<<<<<<< HEAD
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return 0;
 }
 
@@ -301,117 +205,63 @@ int cortx_kvs_discard_transaction(struct kvs_idx *index)
 int cortx_kvs_get_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void **v, size_t *vlen)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS_GET_BIN, PEM_NSAL_TO_MOTR);
-    rc = m0kvs_get(index->index_priv, k, klen, v, vlen);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS_GET_BIN, PEM_NSAL_TO_MOTR);
 	rc = m0kvs_get(index->index_priv, k, klen, v, vlen);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs4_get_bin(void *k, const size_t klen, void **v, size_t *vlen)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS4_GET_BIN, PEM_NSAL_TO_MOTR);
-    rc = m0kvs4_get(k, klen, v, vlen);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS4_GET_BIN, PEM_NSAL_TO_MOTR);
 	rc = m0kvs4_get(k, klen, v, vlen);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_set_bin(struct kvs_idx *index, void *k, const size_t klen,
 		      void *v, const size_t vlen)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS_SET_BIN, PEM_NSAL_TO_MOTR);
-    rc = m0kvs_set(index->index_priv, k, klen, v, vlen);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS_SET_BIN, PEM_NSAL_TO_MOTR);
 	rc = m0kvs_set(index->index_priv, k, klen, v, vlen);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs4_set_bin(void *k, const size_t klen, void *v, const size_t vlen)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS4_SET_BIN, PEM_NSAL_TO_MOTR);
-    rc = m0kvs4_set(k, klen, v, vlen);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS4_SET_BIN, PEM_NSAL_TO_MOTR);
 	rc = m0kvs4_set(k, klen, v, vlen);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_del_bin(struct kvs_idx *index, const void *key, size_t klen)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS_DELETE_BIN, PEM_NSAL_TO_MOTR);
-    rc = m0kvs_del(index->index_priv, (void *) key, klen);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS_DELETE_BIN, PEM_NSAL_TO_MOTR);
 	rc = m0kvs_del(index->index_priv, (void *) key, klen);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_gen_fid(kvs_idx_fid_t *index_fid)
 {
-<<<<<<< HEAD
-    int rc;
-    perfc_trace_inii(PFT_CORTX_KVS_GEN_FID, PEM_NSAL_TO_MOTR);
-    rc = m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-    return rc;
-=======
 	int rc;
 	perfc_trace_inii(PFT_CORTX_KVS_GEN_FID, PEM_NSAL_TO_MOTR);
 	rc = m0kvs_idx_gen_fid((struct m0_uint128 *) index_fid);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
 	return rc;
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 const char *cortx_kvs_get_gfid(void)
@@ -441,25 +291,15 @@ int cortx_kvs_get_list_size(void *ctx, char *pattern, size_t plen)
 	int size = 0;
 	int rc;
 
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_GET_LIST_SIZE, PEM_NSAL_TO_MOTR);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_GET_LIST_SIZE, PEM_NSAL_TO_MOTR);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	strcpy(initk, pattern);
 	initk[plen - 2] = '\0';
 
 	rc = m0kvs_pattern(ctx, initk, pattern,
 			   get_list_cb_size, &size);
-<<<<<<< HEAD
-    perfc_trace_attr(PEA_KVS_LIST_SIZE, size);
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_attr(PEA_KVS_LIST_SIZE, size);
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	if (rc < 0)
 		return rc;
 
@@ -483,15 +323,9 @@ void cortx_kvs_iter_get_kv(struct kvs_itr *iter, void **key, size_t *klen,
                            void **val, size_t *vlen)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_ITER_GET_KV, PEM_NSAL_TO_MOTR);
-	m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_ITER_GET_KV, PEM_NSAL_TO_MOTR);
 	m0kvs_key_iter_get_kv(priv, key, klen, val, vlen);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 int cortx_kvs_prefix_iter_has_prefix(struct kvs_itr *iter)
@@ -521,11 +355,7 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	int rc = 0;
 	struct m0kvs_key_iter *priv = NULL;
 
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FIND, PEM_NSAL_TO_MOTR);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FIND, PEM_NSAL_TO_MOTR);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 
 	priv = cortx_key_iter_priv(iter);
 	priv->index = iter->idx.index_priv;
@@ -536,13 +366,8 @@ int cortx_kvs_prefix_iter_find(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
-<<<<<<< HEAD
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -550,11 +375,7 @@ out:
 int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 {
 	int rc = 0;
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_NEXT, PEM_NSAL_TO_MOTR);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_NEXT, PEM_NSAL_TO_MOTR);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
 	rc = m0kvs_key_iter_next(priv);
 	iter->inner_rc = rc;
@@ -563,13 +384,8 @@ int cortx_kvs_prefix_iter_next(struct kvs_itr *iter)
 	}
 	rc = cortx_kvs_prefix_iter_has_prefix(iter);
 out:
-<<<<<<< HEAD
-    perfc_trace_attr(PEA_NS_RES_RC, rc);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_attr(PEA_NS_RES_RC, rc);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 	return rc;
 }
 
@@ -577,15 +393,9 @@ out:
 void cortx_kvs_prefix_iter_fini(struct kvs_itr *iter)
 {
 	struct m0kvs_key_iter *priv = cortx_key_iter_priv(iter);
-<<<<<<< HEAD
-    perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FINISH, PEM_NSAL_TO_MOTR);
-	m0kvs_key_iter_fini(priv);
-    perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
-=======
 	perfc_trace_inii(PFT_CORTX_KVS_PREFIX_ITER_FINISH, PEM_NSAL_TO_MOTR);
 	m0kvs_key_iter_fini(priv);
 	perfc_trace_finii(PERFC_TLS_POP_DONT_VERIFY);
->>>>>>> f173b7d... EOS-13990: NFS ADDB: Tracepointsfor all ATTR operations (#22)
 }
 
 struct kvstore_ops cortx_kvs_ops = {


### PR DESCRIPTION
resolved conflicts and build failure

-bash-4.2$ sudo ./scripts/test.sh

Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 8
Tests failed = 1

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0
