### PR TITLE
EOS-14572: ADDB : Code refactor (nsal repo)

### DIFF
--- a/src/common/motr/m0common.c
+++ b/src/common/motr/m0common.c
@@ -68,7 +68,7 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 {
 	struct m0_key_iter_priv *priv = m0_key_iter_priv(iter);
 
-	perfc_trace_inii(PFT_M0_KEY_ITER_FINISH, PEM_NFS_TO_MOTR);
+	perfc_trace_inii(PFT_M0_KEY_ITER_FINISH, PEM_NSAL_NFS_TO_MOTR);
 	if (!priv->initialized)
 		goto out;
 
@@ -79,13 +79,13 @@ void m0_key_iter_fini(struct kvstore_iter *iter)
 		perfc_trace_attr(PEA_M0_OP_SM_ID, priv->op->op_sm.sm_id);
 		perfc_trace_attr(PEA_M0_OP_SM_STATE, priv->op->op_sm.sm_state);
 
-		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FINISH);
+		perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_FINISH);
 		m0_op_fini(priv->op);
-		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FINISH);
+		perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_FINISH);
 
-		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FREE);
+		perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_FREE);
 		m0_op_free(priv->op);
-		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FREE);
+		perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_FREE);
 	}
 
 out:
@@ -103,7 +103,7 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 	struct m0_idx *index = iter->idx.index_priv;
 	int rc;
 
-	perfc_trace_inii(PFT_M0_KEY_ITER_FIND, PEM_NFS_TO_MOTR);
+	perfc_trace_inii(PFT_M0_KEY_ITER_FIND, PEM_NSAL_NFS_TO_MOTR);
 	if (prefix_len == 0)
 		rc = m0_bufvec_empty_alloc(key, 1);
 	else
@@ -128,14 +128,14 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 		goto out_free_val;
 	}
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_LAUNCH);
 	m0_op_launch(op, 1);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_LAUNCH);
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_WAIT);
+	perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_WAIT);
 	rc = m0_op_wait(*op, M0_BITS(M0_OS_STABLE),
 			M0_TIME_NEVER);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_WAIT);
+	perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_WAIT);
 
 	perfc_trace_attr(PEA_M0_OP_SM_ID, (*op)->op_sm.sm_id);
 	perfc_trace_attr(PEA_M0_OP_SM_STATE, (*op)->op_sm.sm_state);
@@ -156,13 +156,13 @@ bool m0_key_iter_find(struct kvstore_iter *iter, const void* prefix,
 
 out_free_op:
 	if (op && *op) {
-		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FINISH);
+		perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_FINISH);
 		m0_op_fini(*op);
-		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FINISH);
+		perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_FINISH);
 
-		perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_FREE);
+		perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_FREE);
 		m0_op_free(*op);
-		perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_FREE);
+		perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_FREE);
 	}
 
 out_free_val:
@@ -203,7 +203,7 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 	struct m0_idx *index = iter->idx.index_priv;
 	bool can_get_next = false;
 
-    perfc_trace_inii(PFT_M0_KEY_ITER_NEXT, PEM_NFS_TO_MOTR);
+	perfc_trace_inii(PFT_M0_KEY_ITER_NEXT, PEM_NSAL_NFS_TO_MOTR);
 	assert(priv->initialized);
 
 	/* Motr API: "'vals' vector ... should contain NULLs" */
@@ -219,9 +219,9 @@ bool m0_key_iter_next(struct kvstore_iter *iter)
 		goto out;
 	}
 
-	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_TIME_ATTR_START_NSAL_M0_OP_LAUNCH);
 	m0_op_launch(&priv->op, 1);
-	perfc_trace_attr(PEA_TIME_ATTR_END_M0_OP_LAUNCH);
+	perfc_trace_attr(PEA_TIME_ATTR_END_NSAL_M0_OP_LAUNCH);
 
 	perfc_trace_attr(PEA_TIME_ATTR_START_M0_OP_WAIT);
 	iter->inner_rc = m0_op_wait(priv->op, M0_BITS(M0_OS_STABLE),

--- a/src/include/cfs_nsal_perfc.h
+++ b/src/include/cfs_nsal_perfc.h
@@ -1,0 +1,103 @@
+/*
+ * Filename:	cfs_nsal_perfc.h
+ * Description:	This module defines performance counters and helpers.
+ *
+ * Copyright (c) 2020 Seagate Technology LLC and/or its Affiliates
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * For any questions about this software or licensing,
+ * please email opensource@seagate.com or cortx-questions@seagate.com. 
+ */
+
+#ifndef __CFS_NSAL_PERF_COUNTERS_H_
+#define __CFS_NSAL_PERF_COUNTERS_H_
+/******************************************************************************/
+#include "perf/tsdb.h" /* ACTION_ID_BASE */
+#include "operation.h"
+#include <pthread.h>
+#include <string.h>
+#include "debug.h"
+#include "perf/perf-counters.h"
+
+enum perfc_nsal_function_tags {
+	PFT_KVS_START = PFTR_RANGE_4_START,
+
+	PFT_KVS_INIT,
+	PFT_KVS_FINI,
+	PFT_KVS_ALLOC,
+	PFT_KVS_FREE,
+	PFT_KVS_GET,
+	PFT_KVS_SET,
+	PFT_KVTREE_ITER_CH,
+
+	PFT_CORTX_KVS_INIT,
+	PFT_CORTX_KVS_FINISH,
+	PFT_CORTX_KVS_ALLOC,
+	PFT_CORTX_KVS_FREE,
+	PFT_CORTX_KVS_INDEX_CREATE,
+	PFT_CORTX_KVS_INDEX_DELETE,
+	PFT_CORTX_KVS_INDEX_OPEN,
+	PFT_CORTX_KVS_INDEX_CLOSE,
+	PFT_CORTX_KVS_GET_BIN,
+	PFT_CORTX_KVS4_GET_BIN,
+	PFT_CORTX_KVS_SET_BIN,
+	PFT_CORTX_KVS4_SET_BIN,
+	PFT_CORTX_KVS_DELETE_BIN,
+	PFT_CORTX_KVS_GEN_FID,
+	PFT_CORTX_KVS_PREFIX_ITER_FIND,
+	PFT_CORTX_KVS_PREFIX_ITER_NEXT,
+	PFT_CORTX_KVS_PREFIX_ITER_FINISH,
+	PFT_CORTX_KVS_ITER_GET_KV,
+	PFT_CORTX_KVS_GET_LIST_SIZE,
+
+	PFT_M0_KEY_ITER_FINISH,
+	PFT_M0_KEY_ITER_FIND,
+	PFT_M0_KEY_ITER_NEXT,
+
+	PFT_KVS_END = PFTR_RANGE_4_END,
+};
+
+enum perfc_nsal_entity_attrs {
+	PEA_KVS_START = PEAR_RANGE_4_START,
+
+	PEA_KVS_ALLOC_SIZE,
+	PEA_KVS_ALLOC_RES_RC,
+	PEA_KVS_KLEN,
+	PEA_KVS_VLEN,
+	PEA_KVS_RES_RC,
+
+	PEA_TIME_ATTR_START_NSAL_M0_OP_FINISH,
+	PEA_TIME_ATTR_END_NSAL_M0_OP_FINISH,
+	PEA_TIME_ATTR_START_NSAL_M0_OP_FREE,
+	PEA_TIME_ATTR_END_NSAL_M0_OP_FREE,
+	PEA_TIME_ATTR_START_NSAL_M0_OP_LAUNCH,
+	PEA_TIME_ATTR_END_NSAL_M0_OP_LAUNCH,
+	PEA_TIME_ATTR_START_NSAL_M0_OP_WAIT,
+	PEA_TIME_ATTR_END_NSAL_M0_OP_WAIT,
+
+	PEA_NS_RES_RC,
+	PEA_KVS_LIST_SIZE,
+
+	PEA_KVS_END = PEAR_RANGE_4_END
+};
+
+enum perfc_nsal_entity_maps {
+	PEM_KVS_START = PEMR_RANGE_4_START,
+
+	PEM_NSAL_NFS_TO_MOTR,
+	PEM_NSAL_TO_MOTR,
+	PEM_KVS_TO_NFS,
+
+	PEM_KVS_END = PEMR_RANGE_4_END
+};
+
+/******************************************************************************/
+#endif /* __CFS_NSAL_PERF_COUNTERS_H_ */

--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -28,6 +28,7 @@
 #include <common/helpers.h>
 #include <common/log.h>
 #include "operation.h"
+#include <cfs_nsal_perfc.h>
 
 #define KVSTORE "kvstore"
 #define TYPE "type"

--- a/src/kvstore/plugins/cortx/cortx_kvstore.c
+++ b/src/kvstore/plugins/cortx/cortx_kvstore.c
@@ -25,6 +25,7 @@
 #include "internal/cortx/cortx_kvstore.h"
 #include <cortx/helpers.h>
 #include "operation.h"
+#include <cfs_nsal_perfc.h>
 
 int cortx_kvs_init(struct collection_item *cfg_items)
 {

--- a/src/kvtree/kvtree.c
+++ b/src/kvtree/kvtree.c
@@ -23,6 +23,7 @@
 #include "common/helpers.h" /* RC_WRAP_LABEL */
 #include "md_common.h"
 #include "operation.h"
+#include <cfs_nsal_perfc.h>
 
 #define DEFAULT_ROOT_ID 2LL
 


### PR DESCRIPTION
#  EOS-14572: ADDB : Code refactor (nsal repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT
[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0


IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


commit 85b60364301aa3d22b565cdc5592c272950fdf19
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Mon Nov 2 17:01:34 2020 -0700

            EOS-14572: ADDB : Code refactor (nsal repo)
            List of modified files:
                modified:   src/common/motr/m0common.c
                new file:   src/include/cfs_nsal_perfc.h
                modified:   src/kvstore/kvstore_base.c
                modified:   src/kvstore/plugins/cortx/cortx_kvstore.c
                modified:   src/kvtree/kvtree.c
            Change description:
                    Refactor function tags, maps and attribute enums and move out repo specific code. Introduce ranges. move out plugin.
            Test:
                    On VM: UT, addb traces and graphs
