### PR TITLE
PoC changes for EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (nsal repo) 

### DIFF
--- a/src/include/kvstore.h
+++ b/src/include/kvstore.h
@@ -114,6 +114,13 @@ void kvs_itr_fini(struct kvstore *kvstore, struct kvs_itr *iter);
 void kvs_itr_get(struct kvstore *kvstore, struct kvs_itr *iter, void **key, size_t *klen,
                  void **val, size_t *vlen);
 
+typedef void (*key_memcpy_cb) (void *dst, void *src, size_t size);
+
+int kvs_itr_find_v1(struct kvstore *kvstore, struct kvs_idx *index, void *prefix,
+		    const size_t prefix_len, struct kvs_itr **iter, int batch_size);
+void kvs_itr_get_v1(struct kvstore *kvstore, struct kvs_itr *iter, void **key,
+		    size_t *klen, void **val, size_t *vlen);
+
 struct kvstore_ops {
 	/* Basic constructor and destructor */
 	int (*init) (struct collection_item *cfg);
@@ -148,6 +155,9 @@ struct kvstore_ops {
 	void (*kv_fini) (struct kvs_itr *iter);
 	void (*kv_get) (struct kvs_itr *iter, void **key, size_t *klen,
 	                void **val, size_t *vlen);
+	int (*kv_find_v1) (struct kvs_itr *iter);
+	void (*kv_get_v1) (struct kvs_itr *iter, void **key, size_t *klen,
+			   void **val, size_t *vlen);
 };
 
 int kvs_init(struct kvstore *kvstore, struct collection_item *cfg);
@@ -165,6 +175,7 @@ struct kvs_idx {
 struct kvs_itr {
 	struct kvs_idx idx;
 	buff_t prefix;
+	int batch_size;
 	int inner_rc;
 	char priv[KVSTORE_ITER_PRIV_DATA_SIZE];
 };

--- a/src/include/kvtree.h
+++ b/src/include/kvtree.h
@@ -148,6 +148,9 @@ typedef bool (*kvtree_iter_children_cb)(void *cb_ctx, const char *name,
 int kvtree_iter_children(struct kvtree *tree, const node_id_t *parent_id,
                          kvtree_iter_children_cb cb, void *cb_ctx);
 
+int kvtree_iter_children_v1(struct kvtree *tree, const node_id_t *parent_id,
+                         kvtree_iter_children_cb cb, void *cb_ctx);
+
  /* Check if the passed kvnode has at least one child kvnode linked into it
  * @param[in] tree - kvtree pointer to check the existence of child nodes .
  * @param[in] parent_id - node id  of the kvnode

--- a/src/kvstore/kvstore_base.c
+++ b/src/kvstore/kvstore_base.c
@@ -296,6 +296,30 @@ int kvs_itr_find(struct kvstore *kvstore, struct kvs_idx *index, void *prefix,
 	return kvstore->kvstore_ops->kv_find(*iter);
 }
 
+int kvs_itr_find_v1(struct kvstore *kvstore, struct kvs_idx *index, void *prefix,
+		    const size_t prefix_len, struct kvs_itr **iter,
+		    int batch_size)
+{
+	int rc = 0;
+
+	dassert(kvstore);
+
+	if (*iter == NULL) {
+		rc = kvstore->kvstore_ops->alloc((void **)iter,
+						 sizeof(struct kvs_itr));
+		if (rc) {
+			return rc;
+		}
+		(*iter)->idx.index_priv = index->index_priv;
+		(*iter)->prefix.buf = prefix;
+		(*iter)->prefix.len = prefix_len;
+		(*iter)->batch_size = batch_size;
+	}
+		(*iter)->prefix.buf = prefix;
+		(*iter)->prefix.len = prefix_len;
+	return kvstore->kvstore_ops->kv_find_v1(*iter);
+}
+
 int kvs_itr_next(struct kvstore *kvstore, struct kvs_itr *iter)
 {
 	dassert(kvstore);
@@ -314,6 +338,13 @@ void kvs_itr_get(struct kvstore *kvstore, struct kvs_itr *iter, void **key,
 {
 	dassert(kvstore);
 	return kvstore->kvstore_ops->kv_get(iter, key, klen, val, vlen);
+}
+
+void kvs_itr_get_v1(struct kvstore *kvstore, struct kvs_itr *iter, void **key,
+		    size_t *klen, void **val, size_t *vlen)
+{
+	dassert(kvstore);
+	return kvstore->kvstore_ops->kv_get_v1(iter, key, klen, val, vlen);
 }
 
 int kvpair_alloc(struct kvpair **kv)

--- a/src/kvtree/kvnode.c
+++ b/src/kvtree/kvnode.c
@@ -154,6 +154,51 @@ out:
 	return rc;
 }
 
+#if 0
+int kvnode_load_itr(struct kvtree *tree, const node_id_t *node_id,
+                struct kvnode *node)
+{
+	struct kvnode_key *node_key = NULL;
+	int rc = 0;
+	size_t  val_size = 0;
+	struct kvnode_basic_attr *val = NULL;
+	struct kvnode_key **node_keys;
+	node_keys = alloca(batch_size * sizeof (struct kvnode_key));
+			{
+				KVNODE_KEY_INIT(node_key[j], value[j], KVTREE_KEY_TYPE_BASIC_ATTR);
+			}
+
+	dassert(tree);
+	dassert(node_id);
+	dassert(node);
+
+	struct kvstore *kvstor = kvstore_get();
+	dassert(kvstor);
+
+	RC_WRAP_LABEL(rc, out, kvs_alloc, kvstor, (void **)&node_key,
+	              sizeof(struct kvnode_key));
+
+	KVNODE_KEY_INIT(node_key, *node_id, KVTREE_KEY_TYPE_BASIC_ATTR);
+
+	RC_WRAP_LABEL(rc, free_key, kvs_get, kvstor, &tree->index, node_key,
+	              sizeof(struct kvnode_key), (void **)&val, &val_size);
+
+	dassert(val);
+	dassert(val_size == (sizeof(struct kvnode_basic_attr) + val->size));
+
+	node->tree = tree;
+	node->node_id = *node_id;
+	node->basic_attr = val;
+
+free_key:
+	kvs_free(kvstor, node_key);
+out:
+	log_debug("kvtree=%p, node_id " NODE_ID_F ", rc=%d", tree,
+	           NODE_ID_P(node_id), rc);
+	return rc;
+}
+#endif
+
 int kvnode_delete(const struct kvnode *node)
 {
 	struct kvnode_key *node_key = NULL;


### PR DESCRIPTION
#  EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (nsal repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT
This PoC change does not affect existing production code. The newly introduced readdir v1's UT is work in progress.


## Commit Message
commit 0b6a46a6860f99b9baeadbd264765e9f6ef5b908
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Thu Dec 3 15:31:30 2020 +0000

            PoC changes for EOS-15317: cortxfs perf: Design for cortxfs readdir perf improvement (nsal repo)
            KV iterator with batching
            UT changes for readdir test
        modified:   src/include/kvstore.h
        modified:   src/include/kvtree.h
        modified:   src/kvstore/kvstore_base.c
        modified:   src/kvstore/plugins/cortx/cortx_kvstore.c
        modified:   src/kvtree/kvnode.c
        modified:   src/kvtree/kvtree.c

    Signed-off-by: pratyush-seagate <pratyush.k.khan@seagate.com>